### PR TITLE
Fix droid3 mount command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ echo installing kexec to kexecboot
 adb push scripts/kexecbootstart.sh /sdcard
 adb push kexecboot /sdcard
 adb push root/busybox /sdcard
-adb shell "su -c 'mount -o remount,rw /system'"
+adb shell "su -c 'mount -o remount,rw /dev/block/system /system'"
 adb shell "su -c 'cp -r /sdcard/kexecboot /system/etc/'"
 adb shell "su -c 'cp /system/xbin/true /system/bin/pvrsrvinit'"
 adb shell "su -c 'mv  /system/bin/logwrapper /system/bin/logwrapper-backup'"


### PR DESCRIPTION
Mount command on droid3 requires device path